### PR TITLE
Fix for OSX USB serial detection

### DIFF
--- a/utils/tiny_ble_monitor.py
+++ b/utils/tiny_ble_monitor.py
@@ -28,7 +28,7 @@ class SerialThread(QThread):
         port = None
         for p in list_ports.comports():
             print(p)
-            if p[2].upper().startswith('USB VID:PID=0D28:0204'):
+            if p[2].upper().startswith('USB VID:PID=0D28:0204') or p[2].upper().startswith('USB VID:PID=D28:204'):
                 port = p[0]
                 break
                 


### PR DESCRIPTION
At least on my Macbook Air the USB enumerates with the identification 'USB VID:PID=D28:204' (removing leading zeroes). This fixes the issue.
